### PR TITLE
fix: remove duplicate mental_health/behavioral_health keys from NEED_…

### DIFF
--- a/backend/services/profileNormalizer.js
+++ b/backend/services/profileNormalizer.js
@@ -42,8 +42,6 @@ export const NEED_ALIAS_MAP = {
   healthcare: 'health_medical',
   medical_bills: 'health_medical',
   prescription: 'health_medical',
-  mental_health: 'health_medical',
-  behavioral_health: 'health_medical',
   dental: 'health_medical',
   vision: 'health_medical',
 


### PR DESCRIPTION
## Problem

The CI pipeline fails with two lint errors in `backend/services/profileNormalizer.js`:

- **Line 191**: Duplicate key `'mental_health'`
- - **Line 192**: Duplicate key `'behavioral_health'`
Both keys appear twice in `NEED_ALIAS_MAP`:
1. First in the "Medical / health" section, mapping to `'health_medical'`
2. 2. Then in a dedicated "Mental health" section, mapping to `'mental_health'`
In JavaScript, duplicate object keys cause the second to silently override the first. The linter correctly flags this as an error.

## Fix

Remove the first occurrences of `mental_health` and `behavioral_health` from the "Medical / health" group (which mapped to `'health_medical'`), keeping only the dedicated "Mental health" section mappings (which map to `'mental_health'`). This aligns with the comment "Mental health — split from health_medical for finer matching."